### PR TITLE
Update return types for stream and download methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require": {
         "php": ">=7",
         "barryvdh/laravel-dompdf": "^0.8.5",
+        "illuminate/support": "^6",
         "symfony/http-foundation": "^4.3.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "require": {
         "php": ">=7",
         "barryvdh/laravel-dompdf": "^0.8.5",
-        "illuminate/support": "^6",
-        "symfony/http-foundation": "^4.3.4"
+        "illuminate/support": "^5.5|^6",
+        "illuminate/http": "^5.5|^6"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4",

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -250,7 +250,7 @@ class Invoice
     }
 
     /**
-     * @return mixed
+     * @return Response
      * @throws Exception
      */
     public function stream()
@@ -264,7 +264,7 @@ class Invoice
     }
 
     /**
-     * @return mixed
+     * @return Response
      * @throws Exception
      */
     public function download()

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -117,11 +117,6 @@ class Invoice
     public $hasItemTax;
 
     /**
-     * @var bool
-     */
-    public $hasRendering;
-
-    /**
      * @var int
      */
     public $table_columns;

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -16,7 +16,6 @@ use LaravelDaily\Invoices\Traits\DateFormatter;
 use LaravelDaily\Invoices\Traits\InvoiceHelpers;
 use LaravelDaily\Invoices\Traits\SavesFiles;
 use LaravelDaily\Invoices\Traits\SerialNumberFormatter;
-use Symfony\Component\HttpFoundation\Response as BaseResponse;
 
 /**
  * Class Invoices
@@ -258,7 +257,7 @@ class Invoice
     {
         $this->render();
 
-        return new Response($this->output, BaseResponse::HTTP_OK, [
+        return new Response($this->output, Response::HTTP_OK, [
             'Content-Type'        => 'application/pdf',
             'Content-Disposition' => 'inline; filename="' . $this->filename . '"',
         ]);
@@ -272,7 +271,7 @@ class Invoice
     {
         $this->render();
 
-        return new Response($this->output, BaseResponse::HTTP_OK, [
+        return new Response($this->output, Response::HTTP_OK, [
             'Content-Type'        => 'application/pdf',
             'Content-Disposition' => 'attachment; filename="' . $this->filename . '"',
             'Content-Length'      => strlen($this->output),

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -169,7 +169,7 @@ class Invoice
         $this->currency_format              = config('invoices.currency.format');
 
         $this->disk          = config('invoices.disk');
-        $this->table_columns = self::TABLE_COLUMNS;
+        $this->table_columns = static::TABLE_COLUMNS;
     }
 
     /**
@@ -179,7 +179,7 @@ class Invoice
      */
     public static function make($name = 'Invoice')
     {
-        return new self($name);
+        return new static($name);
     }
 
     /**


### PR DESCRIPTION
While working with Laravel Vapor, it was necessary for me to add an additional header required when returning binary responses per [Vapor's documentation](https://docs.vapor.build/1.0/projects/development.html#binary-responses). I noticed that the return type of `Invoice::download()` and `Invoice::stream()` was `mixed` while they were both explicitly returning an instance of the Illuminate Response class. After forking the package I also noticed a few other subjective fixes that I thought I would squeeze in.

It is now more clear that the return type is an Illuminate Response instance and can be used like so in instances such as when working with Laravel Vapor
```php
return $invoice->pdf()->download()->withHeaders([
    'X-Vapor-Base64-Encode' => 'True',
]);
```