### PR TITLE
QR SUPPORT

### DIFF
--- a/resources/views/templates/default.blade.php
+++ b/resources/views/templates/default.blade.php
@@ -254,11 +254,7 @@
                 {{ trans('invoices::invoice.notes') }}: {!! $invoice->notes !!}
             </p>
         @endif
-        @if($invoice->qr)
-        <p>
-        <img src="{{$qr}}">
-        </p>
-    @endif
+
 
         <p>
             {{ trans('invoices::invoice.amount_in_words') }}: {{ $invoice->getTotalAmountInWords() }}
@@ -266,7 +262,9 @@
         <p>
             {{ trans('invoices::invoice.pay_until') }}: {{ $invoice->getPayUntilDate() }}
         </p>
-
+        @if($invoice->qr)
+        <img src="{{$invoice->qr}}" height="100" width="100">
+        @endif
         <script type="text/php">
             if (isset($pdf) && $PAGE_COUNT > 1) {
                 $text = "Page {PAGE_NUM} / {PAGE_COUNT}";

--- a/resources/views/templates/default.blade.php
+++ b/resources/views/templates/default.blade.php
@@ -254,6 +254,11 @@
                 {{ trans('invoices::invoice.notes') }}: {!! $invoice->notes !!}
             </p>
         @endif
+        @if($invoice->qr)
+        <p>
+        <img src="{{$qr}}">
+        </p>
+    @endif
 
         <p>
             {{ trans('invoices::invoice.amount_in_words') }}: {{ $invoice->getTotalAmountInWords() }}

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -135,6 +135,11 @@ class Invoice
      * @var string
      */
     public $output;
+    /**
+     * @var string
+     * Base64 format.
+     */
+    public $qr;
 
     /**
      * Invoice constructor.

--- a/src/Traits/InvoiceHelpers.php
+++ b/src/Traits/InvoiceHelpers.php
@@ -38,6 +38,13 @@ trait InvoiceHelpers
         return $this;
     }
 
+    public function qr(string $qr)
+    {
+        $this->qr = $qr;
+
+        return $this;
+    }
+
     /**
      * @param float $amount
      * @param bool $byPercent


### PR DESCRIPTION
Hello, if you ever thought of adding QR support on invoices it can be done like this, send to the invoice $qr = "base64 encoded QR", and I added support for the QR in view too, it can be moved around if needed.

I came to this because I was implementing SEPA QR standard to your invoices, it can be done by sending an image path too, in that case, $qr variable would be $qrBase64 and we would need just new variable with image path, for example, $qrImage

Example:
![examplepdf](https://user-images.githubusercontent.com/32557332/89575485-20496e80-d82e-11ea-8f07-d071d34357ea.png)


