### PR TITLE
feat(localization): added nullable parameter $locale to getAmountInWords()

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Almost every configuration value can be overrided dinamically by methods.
 - currencyDecimalPoint(string)
 - currencyThousandsSeparator(string)
 - currencyFormat(string)
-- getAmountInWords(float) - Spells out float to words (only english)
+- getAmountInWords(float, ?string) - Spells out float to words
 - getTotalAmountInWords() - spells out total_amount
 - formatCurrency(float) - returns formatted value with currency settings '$ 1,99'
 

--- a/src/Traits/CurrencyFormatter.php
+++ b/src/Traits/CurrencyFormatter.php
@@ -2,6 +2,7 @@
 
 namespace LaravelDaily\Invoices\Traits;
 
+use Illuminate\Support\Facades\App;
 use NumberFormatter;
 
 /**
@@ -150,7 +151,7 @@ trait CurrencyFormatter
     public function getAmountInWords(float $amount, ?string $locale = null)
     {
         $amount    = number_format($amount, $this->currency_decimals, '.', '');
-        $formatter = new NumberFormatter($locale ?? config('app.locale', 'en'), NumberFormatter::SPELLOUT);
+        $formatter = new NumberFormatter($locale ?? App::getLocale(), NumberFormatter::SPELLOUT);
 
         $value = explode('.', $amount);
 

--- a/src/Traits/CurrencyFormatter.php
+++ b/src/Traits/CurrencyFormatter.php
@@ -144,12 +144,13 @@ trait CurrencyFormatter
 
     /**
      * @param float $amount
+     * @param string|null $locale
      * @return string
      */
-    public function getAmountInWords(float $amount)
+    public function getAmountInWords(float $amount, ?string $locale = null)
     {
         $amount    = number_format($amount, $this->currency_decimals, '.', '');
-        $formatter = new NumberFormatter('en', NumberFormatter::SPELLOUT);
+        $formatter = new NumberFormatter($locale ?? config('app.locale', 'en'), NumberFormatter::SPELLOUT);
 
         $value = explode('.', $amount);
 


### PR DESCRIPTION
Hi all,

I was working with your package when I noticed that `getAmountInWords()` always outputs in English. Since I need invoices in different languages too I modified this method to also be able to:
* use the locale passed to the method;
* use the locale configured in the `app.php` config file;
* default to English.

If there is something wrong with my PR or if you have questions, let me know!