### PR TITLE
Added optional 'extension' parameter for the logo type

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -76,6 +76,11 @@ class Invoice
     public $logo;
 
     /**
+     * @var string
+     */
+    public $logoExtension;
+
+    /**
      * @var float
      */
     public $discount_percentage;

--- a/src/Traits/InvoiceHelpers.php
+++ b/src/Traits/InvoiceHelpers.php
@@ -39,9 +39,10 @@ trait InvoiceHelpers
         return $this;
     }
 
-    public function logo(string $logo)
+    public function logo(string $logo, string $extension = null)
     {
         $this->logo = $logo;
+        $this->logoExtension = $extension;
 
         return $this;
     }
@@ -200,9 +201,9 @@ trait InvoiceHelpers
         return $this->getAmountInWords($this->total_amount);
     }
 
-    public function getLogo(string $type = null)
+    public function getLogo()
     {
-        $type = $type ?? pathinfo($this->logo, PATHINFO_EXTENSION);
+        $type = $this->logoExtension ?? pathinfo($this->logo, PATHINFO_EXTENSION);
         $data = file_get_contents($this->logo);
 
         return 'data:image/' . $type . ';base64,' . base64_encode($data);

--- a/src/Traits/InvoiceHelpers.php
+++ b/src/Traits/InvoiceHelpers.php
@@ -200,9 +200,9 @@ trait InvoiceHelpers
         return $this->getAmountInWords($this->total_amount);
     }
 
-    public function getLogo()
+    public function getLogo(string $type = null)
     {
-        $type = pathinfo($this->logo, PATHINFO_EXTENSION);
+        $type = $type ?? pathinfo($this->logo, PATHINFO_EXTENSION);
         $data = file_get_contents($this->logo);
 
         return 'data:image/' . $type . ';base64,' . base64_encode($data);


### PR DESCRIPTION
Hi! First off, huge thanks for building this package. I love how easy it is to work with! 😄 

This PR just adds an optional `string $extension` parameter to the `logo()` method.

I thought it might be useful because it allows for images to be passed in using signed URLs (such as ones created for S3). For example, in my application, I allow users to upload their own logos that are then placed in the invoices. Because the logos are stored privately, I pass in a temporary signed URL that might look something like this:

```
https://my-app-name-here.s3.eu-west-2.amazonaws.com/teams/1/logo/HceXWX3oW6we9mqptKomjG3F2HRDA7gYJOoDs0V0.png?X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA252AD7Q7LRKE5T4G%2F20211005%2Feu-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211005T161702Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Signature=372b561db7d4bc749d2c9137b44bcb73a5a7b309f05ebba0396b0cbf2ee171f5
```

This means that in the `getLogo()` method, the `pathinfo()` method detects this as being the file extension:

```
png?X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA252AD7Q7LRKE5T4G%2F20211005%2Feu-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211005T161702Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Signature=372b561db7d4bc749d2c9137b44bcb73a5a7b309f05ebba0396b0cbf2ee171f5
```

Because of this, it makes the mime-type in the logo string returned from the `getLogo()` include the query params from the URL and so it can't display the image.

So, with this new change, you could manually pass the expected file extension when setting the path for the logo like so:

```php
$invoiceFile = Invoice::make('invoice')->logo($signedLogoPathHere, 'png');
```

Hopefully, this is something that you think would be worthwhile and helpful. If it's something you might consider pulling in but might need changes, let me know and I'll make them ASAP