### PR TITLE
Include PayDueDate() function in invoice

### DIFF
--- a/resources/lang/en/invoice.php
+++ b/resources/lang/en/invoice.php
@@ -35,4 +35,5 @@ return [
     'shipping'               => 'Shipping',
     'paid'                   => 'Paid',
     'due'                    => 'Due',
+    'due_date'               => 'Invoice Due Date',
 ];

--- a/resources/lang/nl/invoice.php
+++ b/resources/lang/nl/invoice.php
@@ -35,4 +35,5 @@ return [
     'shipping'               => 'Verzending',
     'paid'                   => 'Betaald',
     'due'                    => 'Openstaand',
+    'due_date'               => 'Factuur vervaldag',
 ];

--- a/resources/views/templates/default.blade.php
+++ b/resources/views/templates/default.blade.php
@@ -152,7 +152,7 @@
                         <p>{{ __('invoices::invoice.date') }}: <strong>{{ $invoice->getDate() }}</strong></p>
 
                         @if($invoice->getPayDueDate())
-                        <p>{{ __('invoices::invoice.due_date') }}: <strong>{{ $invoice->getDate() }}</strong></p>
+                            <p>{{ __('invoices::invoice.due_date') }}: <strong>{{ $invoice->getPayDueDate() }}</strong></p>
                         @endif
                     </td>
                 </tr>

--- a/resources/views/templates/default.blade.php
+++ b/resources/views/templates/default.blade.php
@@ -150,6 +150,10 @@
                         @endif
                         <p>{{ __('invoices::invoice.serial') }} <strong>{{ $invoice->getSerialNumber() }}</strong></p>
                         <p>{{ __('invoices::invoice.date') }}: <strong>{{ $invoice->getDate() }}</strong></p>
+
+                        @if($invoice->getPayDueDate())
+                        <p>{{ __('invoices::invoice.due_date') }}: <strong>{{ $invoice->getDate() }}</strong></p>
+                        @endif
                     </td>
                 </tr>
             </tbody>

--- a/src/Traits/DateFormatter.php
+++ b/src/Traits/DateFormatter.php
@@ -25,6 +25,12 @@ trait DateFormatter
      */
     public $pay_until_days;
 
+
+    /**
+     * @var Carbon
+     */
+    public $due_date;
+
     /**
      * @param Carbon $date
      * @return $this
@@ -72,5 +78,22 @@ trait DateFormatter
     public function getPayUntilDate()
     {
         return $this->date->copy()->addDays($this->pay_until_days)->format($this->date_format);
+    }
+
+    /**
+     * @param Carbon $date
+     * @return $this
+     */
+    public function payDueDate(Carbon $dt){
+        $this->due_date = $dt;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPayDueDate()
+    {
+        return $this->due_date ? $this->due_date->format($this->date_format) : null;
     }
 }


### PR DESCRIPTION
This PR is to introduce a new function called "payDueDate" which provides the community to have the opportunity to include the due date of the invoice.

To use the function, the community can only directly call payDueDate() in their invoice object. As below example shown:
```
        $invoice = Invoice::make("QUOTATION")
            ->series('BIG')
            // ability to include translated invoice status
            // in case it was paid
            ->sequence(667)
            ->serialNumberFormat('{SEQUENCE}/{SERIES}')
            ->seller($client)
            ->buyer($customer)
            ->date(now()->subWeeks(3))
            ->payDueDate(now()->addDay()) //this is the payDueDate function
```

As below image shown, this is how the due date look like
![image](https://user-images.githubusercontent.com/50147719/140270903-9ee7390b-3361-48a8-80bf-4a075170697d.png)

