### PR TITLE
Remove setOptions to prevent override config

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -257,7 +257,7 @@ class Invoice
         $view     = View::make($template, ['invoice' => $this]);
         $html     = mb_convert_encoding($view, 'HTML-ENTITIES', 'UTF-8');
 
-        $this->pdf    = PDF::setOptions(['enable_php' => true])->loadHtml($html);
+        $this->pdf    = PDF::loadHtml($html);
         $this->output = $this->pdf->output();
 
         return $this;


### PR DESCRIPTION
Dompdf's `setOptions` will override the settings instead of merging them.

For example, when specify the `chroot` option in `config/dompdf.php`, after the `setOptions` was called, it will be reverted to the default vendor directory.

It seems that the `enable_php` option was never used, so it could possibly be removed.