### PR TITLE
Add base install command to readme installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Please see the [changelog](CHANGELOG.md) for more information on what has change
 
 Via Composer
 
+```bash
+$ composer require laraveldaily/laravel-invoices
+```
+
 ### Laravel version <= 8
 
 ```bash


### PR DESCRIPTION
I'm using Laravel 8. When installing the package, I needed to install by using the added bash command, instead of the command referenced for Laravel 8 and below.

I added the base install command for others that may run into the same issue I did. 

**When running:**
```bash
$ composer require laraveldaily/laravel-invoices:^2.0
```
**I was getting composer errors for the dompdf package.** 

**When I ran:**
```bash
$ composer require laraveldaily/laravel-invoices
```
**everything worked just fine.**