### PR TITLE
Change `setOptions` to `setOption` to avoid overriding the config

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -257,7 +257,7 @@ class Invoice
         $view     = View::make($template, ['invoice' => $this]);
         $html     = mb_convert_encoding($view, 'HTML-ENTITIES', 'UTF-8');
 
-        $this->pdf    = Pdf::setOptions(['enable_php' => true])->loadHtml($html);
+        $this->pdf    = Pdf::setOption(['enable_php' => true])->loadHtml($html);
         $this->output = $this->pdf->output();
 
         return $this;


### PR DESCRIPTION
In the newer version of laravel dompdf, the `setOptions` was depercated, see https://github.com/barryvdh/laravel-dompdf/commit/00443b33aff68f9e996de536c8f62735c4042131

Also, this address and should fix the problem mentioned in pr https://github.com/LaravelDaily/laravel-invoices/pull/127
