### PR TITLE
Add optional Quantity formatting methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,13 @@ Almost every configuration value can be overrided dynamically by methods.
 - getTotalAmountInWords() - spells out total_amount
 - formatCurrency(float) - returns formatted value with currency settings '$ 1,99'
 
+#### Quantity
+- quantityDecimals(int)
+- quantityThousandsSeparator(string)
+- quantityDecimalPoint(string)
+- formatQuantityFixed(float) - returns formatted value with quantity settings '1.00' or '1,00' or '1,25'
+- formatQuantityDynamic(float) - returns formatted value with quantity settings and dynamic decimal numbers '1' or '1,25'
+
 #### File
 - stream() - opens invoice in browser
 - download() - offers to download invoice

--- a/config/invoices.php
+++ b/config/invoices.php
@@ -57,6 +57,22 @@ return [
         'format' => '{VALUE} {SYMBOL}',
     ],
 
+    'quantity' => [
+        /*
+         * Example: 19.00
+         */
+        'decimals' => 2,
+        /*
+         * Example: 1.99
+         */
+        'decimal_point' => '.',
+        /*
+         * By default empty.
+         * Example: 1,999.00
+         */
+        'thousands_separator' => '',
+    ],
+
     'paper' => [
         // A4 = 210 mm x 297 mm = 595 pt x 842 pt
         'size'        => 'a4',

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -187,9 +187,9 @@ class Invoice
         $this->currency_format              = config('invoices.currency.format');
 
         // Quantity
-        $this->quantity_decimals            = config('invoices.currency.decimals');
-        $this->quantity_decimal_point       = config('invoices.currency.decimal_point');
-        $this->quantity_thousands_separator = config('invoices.currency.thousands_separator');
+        $this->quantity_decimals            = config('invoices.quantity.decimals');
+        $this->quantity_decimal_point       = config('invoices.quantity.decimal_point');
+        $this->quantity_thousands_separator = config('invoices.quantity.thousands_separator');
 
         $this->disk          = config('invoices.disk');
         $this->table_columns = static::TABLE_COLUMNS;

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -14,6 +14,7 @@ use LaravelDaily\Invoices\Contracts\PartyContract;
 use LaravelDaily\Invoices\Traits\CurrencyFormatter;
 use LaravelDaily\Invoices\Traits\DateFormatter;
 use LaravelDaily\Invoices\Traits\InvoiceHelpers;
+use LaravelDaily\Invoices\Traits\QuantityFormatter;
 use LaravelDaily\Invoices\Traits\SavesFiles;
 use LaravelDaily\Invoices\Traits\SerialNumberFormatter;
 
@@ -25,6 +26,7 @@ class Invoice
     use CurrencyFormatter;
     use DateFormatter;
     use InvoiceHelpers;
+    use QuantityFormatter;
     use SavesFiles;
     use SerialNumberFormatter;
 
@@ -183,6 +185,11 @@ class Invoice
         $this->currency_decimal_point       = config('invoices.currency.decimal_point');
         $this->currency_thousands_separator = config('invoices.currency.thousands_separator');
         $this->currency_format              = config('invoices.currency.format');
+
+        // Quantity
+        $this->quantity_decimals            = config('invoices.currency.decimals');
+        $this->quantity_decimal_point       = config('invoices.currency.decimal_point');
+        $this->quantity_thousands_separator = config('invoices.currency.thousands_separator');
 
         $this->disk          = config('invoices.disk');
         $this->table_columns = static::TABLE_COLUMNS;

--- a/src/Traits/QuantityFormatter.php
+++ b/src/Traits/QuantityFormatter.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace LaravelDaily\Invoices\Traits;
+
+use Illuminate\Support\Facades\App;
+use NumberFormatter;
+
+/**
+ * Trait QuantityFormatter
+ * @package LaravelDaily\Invoices\Traits
+ */
+trait QuantityFormatter
+{
+    /**
+     * @var int
+     */
+    public $quantity_decimals;
+
+    /**
+     * @var string
+     */
+    public $quantity_decimal_point;
+
+    /**
+     * @var string
+     */
+    public $quantity_thousands_separator;
+
+    /**
+     * @param int $decimals
+     * @return $this
+     */
+    public function quantityDecimals(int $decimals)
+    {
+        $this->quantity_decimals = $decimals;
+
+        return $this;
+    }
+
+    /**
+     * @param string $decimal_point
+     * @return $this
+     */
+    public function quantityDecimalPoint(string $decimal_point)
+    {
+        $this->quantity_decimal_point = $decimal_point;
+
+        return $this;
+    }
+
+    /**
+     * @param string $thousands_separator
+     * @return $this
+     */
+    public function quantityThousandsSeparator(string $thousands_separator)
+    {
+        $this->quantity_thousands_separator = $thousands_separator;
+
+        return $this;
+    }
+
+    /**
+     * @param float $quantity
+     * @return string
+     */
+    public function formatQuantityFixed(float $quantity)
+    {
+        return number_format(
+            $quantity,
+            $this->quantity_decimals,
+            $this->quantity_decimal_point,
+            $this->quantity_thousands_separator
+        );
+    }
+
+    /**
+     * @param float $quantity
+     * @return string
+     */
+    public function formatQuantityDynamic(float $quantity)
+    {
+        $countDecimals = (int) strpos(strrev((float)$quantity), ".");
+
+        return number_format(
+            $quantity,
+            $countDecimals,
+            $this->quantity_decimal_point,
+            $this->quantity_thousands_separator
+        );
+    }
+
+}


### PR DESCRIPTION
The value quantity is displayed as a float, examples are 1 and 1.25
In Europe we display values with comma so I have added a QuantityFormatter trait to add this option to the package.

People have 3 options:

1. change nothing in the blade file
`{{ $item->quantity }}`
This will display 1 or 1.25

2. use fixed number formatting
`{{ $invoice->formatQuantityFixed($item->quantity) }}`
This will display based on the config options 1.00 - 1,00 - 1.25 - 1,25

3. use dynamic number formatting
`{{ $invoice->formatQuantityDynamic($item->quantity) }}`
This will display based on the config options 1 - 1.25 - 1,25 - 1.265 - 1.265,18
