### PR TITLE
use file mime type instead of file extension for generating logo url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "php": "^7.3|^8.0",
         "barryvdh/laravel-dompdf": "^v2.0",
         "illuminate/http": "^5.5|^6|^7|^8|^9",
-        "illuminate/support": "^5.5|^6|^7|^8|^9"
+        "illuminate/support": "^5.5|^6|^7|^8|^9",
+        "symfony/http-foundation": "^4.0|^5.0|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",

--- a/src/Traits/InvoiceHelpers.php
+++ b/src/Traits/InvoiceHelpers.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Support\Str;
 use LaravelDaily\Invoices\Contracts\PartyContract;
 use LaravelDaily\Invoices\Services\PricingService;
+use Symfony\Component\HttpFoundation\File\File;
 
 /**
  * Trait InvoiceHelpers.
@@ -202,10 +203,9 @@ trait InvoiceHelpers
 
     public function getLogo()
     {
-        $type = pathinfo($this->logo, PATHINFO_EXTENSION);
-        $data = file_get_contents($this->logo);
+        $file = new File($this->logo);
 
-        return 'data:image/' . $type . ';base64,' . base64_encode($data);
+        return 'data:' . $file->getMimeType() . ';base64,' . base64_encode($file->getContent());
     }
 
     /**


### PR DESCRIPTION
Hello, thanks for this amazing package!

I've stumbled into error with logos in .svg format. According to [RFC 2397](https://www.rfc-editor.org/rfc/rfc2397#section-3) (The "data" URL scheme), the `mediatype` of data URL are values from [RFC 2045](https://www.rfc-editor.org/rfc/rfc2045) (MIME for short). The only one valid MIME type for .svg files is `image/svg+xml`, so URL with `image/svg` media type is invalid.

This PR fixes this error by using Symfony file class, which has build-in MIME detection tools.