### PR TITLE
Update dompdf & add basic encryption to prevent changes to invoices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "keywords": ["Laravel", "Invoice", "Invoices", "PDF"],
     "require": {
         "php": ">=8.2",
-        "barryvdh/laravel-dompdf": "^v2.0",
+        "barryvdh/laravel-dompdf": "^v3.0",
         "illuminate/http": "^10|^11",
         "illuminate/support": "^10|^11",
         "symfony/http-foundation": "^6|^7"

--- a/config/invoices.php
+++ b/config/invoices.php
@@ -112,4 +112,8 @@ return [
          */
         'logOutputFile' => '/dev/null',
     ],
+
+    'security' => [
+        'encryption' => true,
+    ]
 ];

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\View;
+use Illuminate\Support\Str;
 use LaravelDaily\Invoices\Classes\InvoiceItem;
 use LaravelDaily\Invoices\Classes\Party;
 use LaravelDaily\Invoices\Contracts\PartyContract;
@@ -276,8 +277,13 @@ class Invoice
         $this->pdf = PDF::setOptions($this->options)
             ->setPaper($this->paperOptions['size'], $this->paperOptions['orientation'])
             ->loadHtml($html);
-        $this->output = $this->pdf->output();
 
+        if (config('invoices.security.encryption')) {
+            // By definition an invoice should not be changable by anyone, so use a random master password
+            $this->pdf->setEncryption('', Str::random(40), array('copy','print'));
+        }
+
+        $this->output = $this->pdf->output();
         return $this;
     }
 


### PR DESCRIPTION
This will update dompdf to version 3
and add basic encryption to prevent changes

An invoice should never be changed by anyone. This PR will at least prevent basic changes.
DomPdf only allows for low 40bit encryption, but to keep the dependencies low I did not include a higher encryption algorithm.

