### PR TITLE
Define custom template

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ return Invoice::make()->buyer($customer)->addItem($item)->stream();
 
 After publishing assets you can modify or make your own template for invoices.
 
-Templates are stored in the `resources/views/vendor/invoices/templates` directory. There you will find `default.blade.php` template which is used by default.
+Templates are stored in the `resources/views/vendor/invoices/templates` directory by default. There you will find `default.blade.php` template which is used by default.
 
 You can specify which template to use by calling `template` method on Invoice object.
 
@@ -216,6 +216,13 @@ Invoice::make('receipt')->template('my_company');
 ```
 
 Too see how things work in a template you can view `default.blade.php` as an example.
+
+You can also define your own template path in this way.
+
+For example, if your application follows a modular architecture and stores resources in module-specific directories (e.g., `modules/users/resources/views/invoices/v1/simple.blade.php`), you can configure the path as follows:
+```php
+Invoice::make('receipt')->template('users::invoices.v1.simple', true);
+```
 
 ## Config
 

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -168,7 +168,7 @@ class Invoice
         $this->name     = $name ?: __('invoices::invoice.invoice');
         $this->seller   = app()->make(config('invoices.seller.class'));
         $this->items    = Collection::make([]);
-        $this->template = 'default';
+        $this->template = 'invoices::templates.default';
 
         // Date
         $this->date           = Carbon::now();
@@ -269,8 +269,7 @@ class Invoice
 
         $this->beforeRender();
 
-        $template = sprintf('invoices::templates.%s', $this->template);
-        $view     = View::make($template, ['invoice' => $this]);
+        $view     = View::make($this->template, ['invoice' => $this]);
         $html     = mb_convert_encoding($view, 'HTML-ENTITIES', 'UTF-8');
 
         $this->pdf = PDF::setOptions($this->options)
@@ -283,9 +282,7 @@ class Invoice
 
     public function toHtml()
     {
-        $template = sprintf('invoices::templates.%s', $this->template);
-
-        return View::make($template, ['invoice' => $this]);
+        return View::make($this->template, ['invoice' => $this]);
     }
 
     /**

--- a/src/Traits/InvoiceHelpers.php
+++ b/src/Traits/InvoiceHelpers.php
@@ -176,13 +176,16 @@ trait InvoiceHelpers
     /**
      * @return $this
      */
-    public function template(string $template = 'default')
+    public function template(string $template = 'default', bool $from_default_resources = true)
     {
+        if ($from_default_resources) {
+            $template = sprintf('invoices::templates.%s', $template);
+        }
+
         $this->template = $template;
 
         return $this;
     }
-
     /**
      * @return $this
      */


### PR DESCRIPTION
This pull request enhances the flexibility of the template() method, allowing you to load templates from any view folder, not just resources/views/templates/.

The template() method now accepts a second parameter. By passing true as the second argument, users can specify any custom view path for their templates.