### PR TITLE
Allow Dynamic Properties in Party class [PHP 8.3]

### DIFF
--- a/src/Classes/Party.php
+++ b/src/Classes/Party.php
@@ -7,6 +7,7 @@ use LaravelDaily\Invoices\Contracts\PartyContract;
 /**
  * Class Party
  */
+#[\AllowDynamicProperties]
 class Party implements PartyContract
 {
     public $custom_fields;


### PR DESCRIPTION
Allow Dynamic Properties in Party class

This warning is generated for all custom properties. Resolved with using #[\AllowDynamicProperties] attribute

This resolves issue https://github.com/LaravelDaily/laravel-invoices/issues/253

`DEPRECATED  Creation of dynamic property LaravelDaily\Invoices\Classes\Party::$<variable> is deprecated in vendor/laraveldaily/laravel-invoices/src/Classes/Party.php on line 23.`