### PR TITLE
Remove logOutputFile option pointing to /dev/null

### DIFF
--- a/config/invoices.php
+++ b/config/invoices.php
@@ -106,10 +106,5 @@ return [
 
     'dompdf_options' => [
         'enable_php' => true,
-        /**
-         * Do not write log.html or make it optional
-         *  @see https://github.com/dompdf/dompdf/issues/2810
-         */
-        'logOutputFile' => '/dev/null',
     ],
 ];


### PR DESCRIPTION
DomPDF already handles this internally, so the explicit configuration is no longer necessary.