### PR TITLE
Feature: Support multiple item tax grouping in invoice summary

### DIFF
--- a/resources/views/templates/default.blade.php
+++ b/resources/views/templates/default.blade.php
@@ -330,14 +330,37 @@
                         </td>
                     </tr>
                 @endif
-                @if($invoice->hasItemOrInvoiceTax())
+                @php
+                $groupedTaxes = $invoice->getGroupedTaxes();
+                @endphp
+
+                @if(count($groupedTaxes) > 1)
+
+                    @foreach($groupedTaxes as $rate => $values)
+                        <tr>
+                            <td colspan="{{ $invoice->table_columns - 2 }}" class="border-0"></td>
+                            <td class="text-right pl-0">
+                                {{ __('invoices::invoice.tax') }} ({{ $rate }}%)
+                            </td>
+                            <td class="text-right pr-0">
+                                {{ $invoice->formatCurrency($values['tax']) }}
+                            </td>
+                        </tr>
+                    @endforeach
+
+                @elseif($invoice->hasItemOrInvoiceTax())
+
+                    {{-- Original behaviour --}}
                     <tr>
                         <td colspan="{{ $invoice->table_columns - 2 }}" class="border-0"></td>
-                        <td class="text-right pl-0">{{ __('invoices::invoice.total_taxes') }}</td>
+                        <td class="text-right pl-0">
+                            {{ __('invoices::invoice.total_taxes') }}
+                        </td>
                         <td class="text-right pr-0">
                             {{ $invoice->formatCurrency($invoice->total_taxes) }}
                         </td>
                     </tr>
+
                 @endif
                 @if($invoice->shipping_amount)
                     <tr>

--- a/src/Traits/InvoiceHelpers.php
+++ b/src/Traits/InvoiceHelpers.php
@@ -3,6 +3,7 @@
 namespace LaravelDaily\Invoices\Traits;
 
 use Exception;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use LaravelDaily\Invoices\Contracts\PartyContract;
 use LaravelDaily\Invoices\Services\PricingService;
@@ -276,7 +277,39 @@ trait InvoiceHelpers
         $this->total_amount   = $newTotalAmount;
         $this->total_discount = $totalAmount - $newTotalAmount;
     }
-
+    public function getGroupedTaxes(): array
+    {
+        $grouped = [];
+    
+        foreach ($this->items as $item) {
+    
+            $rate = (float) ($item->tax_percentage ?? 0);
+    
+            if ($rate == 0) {
+                continue;
+            }
+    
+            if (!isset($grouped[$rate])) {
+                $grouped[$rate] = [
+                    'net' => 0,
+                    'tax' => 0,
+                    'gross' => 0,
+                ];
+            }
+    
+            $gross = (float) $item->sub_total_price;
+            $tax   = (float) $item->tax;
+            $net   = $gross - $tax;
+    
+            $grouped[$rate]['net']   += $net;
+            $grouped[$rate]['tax']   += $tax;
+            $grouped[$rate]['gross'] += $gross;
+        }
+    
+        ksort($grouped);
+    
+        return $grouped;
+    }  
     public function calculateTax(): void
     {
         if ($this->taxable_amount) {


### PR DESCRIPTION
### Feature: Multiple Item Tax Rates Support

This PR adds support for multiple item tax rates grouped in the invoice summary.

Currently the package allows:
- Tax on invoice level OR
- Tax on item level

However, when multiple items use different tax rates (e.g. 7% and 19%), the summary only shows a combined tax amount.

This PR introduces:

- Grouping of item taxes by tax rate
- Automatic breakdown in summary section
- Full backward compatibility
- No breaking changes

When multiple item tax rates are present, the invoice summary will display:

Tax (7%)
Tax (19%)

If only one tax rate exists, the original behaviour remains unchanged.